### PR TITLE
DI working dir is reset between jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,15 +5,6 @@ on:
     types: [created]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-      - run: npm ci
-  
   eslint:
     needs: build
     runs-on: ubuntu-latest
@@ -22,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v1
         with: 
           node-version: 12
+      - run: npm ci
       - run: npm run eslint
   
   publish-npm:


### PR DESCRIPTION
The working directory for GitHub Actions jobs is being reset between jobs, so we have to run `npm ci` inside each job.