### PR TITLE
CD: do not depend on non-existing jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   eslint:
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
We shouldn't depend on the `build` job anymore. It has been removed.