### PR TITLE
NPM package has to be public

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: 12
           registry-url: https://registry.npmjs.org/
       - run: npm ci
-      - run: npm publish --tag ${{github.event.release.prerelease && 'dev' || 'latest'}}
+      - run: npm publish --access public --tag ${{github.event.release.prerelease && 'dev' || 'latest'}}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 


### PR DESCRIPTION
We set the GitHub Package to be public, that's fine but the NPM package is the one that has to be public.