### PR TITLE
Depth argument of flat is not applied #16

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -204,7 +204,7 @@ export const Iterator = {
      * @return {Iterator}
      */
     flat(depth = 1) {
-        return Iterator.new(this.rawFlat(null, depth));
+        return Iterator.new(this.rawFlat(depth));
     },
 
     /**
@@ -239,7 +239,7 @@ export const Iterator = {
 
             const innerIter = Iterator.new(item);
 
-            for (const inner of innerIter.rawFlat(null, depth - 1)) {
+            for (const inner of innerIter.rawFlat(depth - 1)) {
                 yield inner;
             }
         }


### PR DESCRIPTION
We are passing too many arguments to the `rawFlat` generator. 